### PR TITLE
added unity spawn child process crash handler

### DIFF
--- a/src/unity_invoker.ts
+++ b/src/unity_invoker.ts
@@ -16,7 +16,6 @@ export async function runUnityProcess(options: IUnityOptions, logger: SimpleLogg
     unityProcess.on('error', async (err) => {
         logger('Error spawning Unity process: ' + err);
     });
-    
     //=> Watch process' stdout to log in real time, and keep the complete output in case of crash
     let stdoutAggregator = '';
     function stdoutHandler(buffer: Buffer) {

--- a/src/unity_invoker.ts
+++ b/src/unity_invoker.ts
@@ -13,10 +13,10 @@ export async function runUnityProcess(options: IUnityOptions, logger: SimpleLogg
 
     //=> Spawn Unity process
     const unityProcess = spawn(await getUnityPath(), argv);
-    unityProcess.on('error', function(err) {
+    unityProcess.on('error', async (err) => {
         logger('Error spawning Unity process: ' + err);
-      });
-
+    });
+    
     //=> Watch process' stdout to log in real time, and keep the complete output in case of crash
     let stdoutAggregator = '';
     function stdoutHandler(buffer: Buffer) {

--- a/src/unity_invoker.ts
+++ b/src/unity_invoker.ts
@@ -13,6 +13,9 @@ export async function runUnityProcess(options: IUnityOptions, logger: SimpleLogg
 
     //=> Spawn Unity process
     const unityProcess = spawn(await getUnityPath(), argv);
+    unityProcess.on('error', function(err) {
+        logger('Error spawning Unity process: ' + err);
+      });
 
     //=> Watch process' stdout to log in real time, and keep the complete output in case of crash
     let stdoutAggregator = '';


### PR DESCRIPTION
Hi, while integrating the AssetBundleCompiler in my Node/Express API I came across the problem of providing the wrong/missspelled Unity path to the library which resulted in an EONET when trying to spawn the UnityProcess in unity_envoker.ts/unity_envoker.js.

I added an error handler for this situation so that the calling application (in my case my API mentioned above) will receive a callback if this happens and can in return notify its calling application (e.g. web client) that there was an error/crash in the back end.

Let me know what you think. I would appreciate if you accepted my pull request...

Thanks